### PR TITLE
fix bug related to files in root directory of buckets; closes #18

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: s3
 Title: Download Files from AWS S3
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person(given = "Cole",
            family = "Brokamp",

--- a/R/s3_parse_uri.R
+++ b/R/s3_parse_uri.R
@@ -13,11 +13,16 @@ s3_parse_uri <- function(s3_uri) {
         fs::path_join() %>%
         as.character()
 
-    if (length(file_path_parts) == 3) folder <- NULL # if file is in root of bucket (no folder)
-
+  # check for files in root of bucket
+  if (length(file_path_parts) == 3) {
+    folder <- ""
+    key <- file_name
+  }
+  else {
     key <-
-        fs::path_join(c(folder, file_name)) %>%
-        as.character()
+      fs::path_join(c(folder, file_name)) %>%
+      as.character()
+  }
 
     s3_url <- glue::glue("https://{bucket}.s3.amazonaws.com/{key}")
 

--- a/tests/testthat/test-s3_get.R
+++ b/tests/testthat/test-s3_get.R
@@ -91,3 +91,18 @@ test_that("s3_get force public download with aws creds", {
   })
   delete_test_download_folder()
 })
+
+test_that("s3_get downloads a file in the root of a bucket", {
+  skip_if_offline(host = "r-project.org")
+  delete_test_download_folder()
+  withr::with_envvar(new = c(
+    "AWS_ACCESS_KEY_ID" = NA,
+    "AWS_SECRET_ACCESS_KEY" = NA
+  ), {
+    expect_identical(
+      readRDS(s3_get("s3://geomarker/mtcars.rds")),
+      mtcars
+    )
+  })
+  delete_test_download_folder()
+})

--- a/tests/testthat/test-s3_get_files.R
+++ b/tests/testthat/test-s3_get_files.R
@@ -89,3 +89,18 @@ test_that("s3_get_files doesn't download files that already exist", {
   )
   delete_test_download_folder()
   })
+
+test_that("s3_get_files downloads public files in bucket's root folder", {
+  skip_if_offline(host = "r-project.org")
+  delete_test_download_folder()
+  expect_identical({
+      dl_results <- s3_get_files(s3_uri = c(
+        "s3://geomarker/mtcars.rds",
+        "s3://geomarker/mtcars_again.rds"
+      ), confirm = FALSE)
+      lapply(dl_results$file_path, readRDS)
+    },
+    list(mtcars, mtcars)
+  )
+  delete_test_download_folder()
+})

--- a/tests/testthat/test-s3_parse_uri.R
+++ b/tests/testthat/test-s3_parse_uri.R
@@ -33,7 +33,7 @@ test_that("s3_parse_uri works with no folders in URI", {
       uri = "s3://geomarker/mtcars.rds",
       bucket = "geomarker",
       key = "mtcars.rds",
-      folder = NULL,
+      folder = "",
       file_name = "mtcars.rds",
       url = "https://geomarker.s3.amazonaws.com/mtcars.rds"
     )


### PR DESCRIPTION
- parsing the URI of an object in the root of a bucket's directory
structure now returns `""` instead of `NULL`
- this prevents downstream problems within `s3_get_files()`